### PR TITLE
feat: add --ignore-path to exclude a folder and its subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Commands and their descriptions are listed below:
 | `--find-owner <path>` | Find the owner of a specific file or folder |
 | `--check` | Run validation checks on features (e.g., duplicate names) |
 | `--skip-changes` | Skip computing git commit history (faster for large repos) |
+| `--ignore-path <path>` | Ignore a folder and all its subfolders when scanning for features. Can be repeated to ignore multiple folders |
 | `--serve` | Start an HTTP server to serve features and the web dashboard UI |
 | `--port <port>` | Change the port (default: 3000). Should be used with `--serve` |
 | `--build` | Build a static version of the web dashboard UI |

--- a/tools/cli/src/bin.rs
+++ b/tools/cli/src/bin.rs
@@ -110,6 +110,41 @@ struct Cli {
     /// Custom prefix for owner names in CODEOWNERS file (default: @)
     #[arg(long, default_value = "@")]
     codeowners_prefix: String,
+
+    /// Ignore a folder and all its subfolders when scanning for features (can be repeated)
+    #[arg(long)]
+    ignore_path: Vec<std::path::PathBuf>,
+}
+
+/// Resolve `--ignore-path` values to canonical absolute paths.
+///
+/// Relative paths are resolved against `current_dir`. Paths that don't exist are
+/// skipped with a warning rather than causing a hard error.
+fn resolve_ignore_paths(
+    ignore_paths: &[std::path::PathBuf],
+    current_dir: &std::path::Path,
+) -> Vec<std::path::PathBuf> {
+    ignore_paths
+        .iter()
+        .filter_map(|raw_path| {
+            let candidate = if raw_path.is_absolute() {
+                raw_path.clone()
+            } else {
+                current_dir.join(raw_path)
+            };
+
+            match std::fs::canonicalize(&candidate) {
+                Ok(canonical) => Some(canonical),
+                Err(_) => {
+                    eprintln!(
+                        "Warning: --ignore-path '{}' does not exist, skipping.",
+                        raw_path.display()
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
 }
 
 fn flatten_features(features: &[Feature]) -> Vec<Feature> {
@@ -285,7 +320,10 @@ async fn main() -> Result<()> {
         };
 
         let current_dir = std::env::current_dir()?;
-        let config = ScanConfig::new(&current_dir).skip_changes(args.skip_changes);
+        let ignore_paths = resolve_ignore_paths(&args.ignore_path, &current_dir);
+        let config = ScanConfig::new(&current_dir)
+            .skip_changes(args.skip_changes)
+            .ignore_paths(ignore_paths);
 
         let features = scan_features(&base_path, config)?;
 
@@ -351,10 +389,12 @@ async fn main() -> Result<()> {
     // Build scan configuration
     let current_dir = std::env::current_dir()?;
     let should_add_coverage = args.serve || args.build || args.json || args.coverage;
+    let ignore_paths = resolve_ignore_paths(&args.ignore_path, &current_dir);
 
     let mut config = ScanConfig::new(&current_dir)
         .skip_changes(args.skip_changes)
-        .with_coverage(should_add_coverage);
+        .with_coverage(should_add_coverage)
+        .ignore_paths(ignore_paths.clone());
 
     if let Some(ref coverage_dir) = args.coverage_dir {
         config = config.coverage_dir(coverage_dir);
@@ -392,6 +432,7 @@ async fn main() -> Result<()> {
                     pb_clone.finish_and_clear();
                 })),
                 args.skip_changes,
+                ignore_paths.clone(),
             )
             .await?;
         } else {
@@ -401,6 +442,7 @@ async fn main() -> Result<()> {
                 path.clone(),
                 None,
                 args.skip_changes,
+                ignore_paths.clone(),
             )
             .await?;
         }

--- a/tools/cli/src/file_scanner.rs
+++ b/tools/cli/src/file_scanner.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use git2::Repository;
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::dependency_resolver::{
     build_file_to_feature_map, collect_feature_info, resolve_feature_dependencies,
@@ -43,6 +43,19 @@ fn is_direct_subfolder_of_features(dir_path: &Path) -> bool {
         return parent_name == "features";
     }
     false
+}
+
+/// Check if a directory is ignored, i.e. matches (or is nested inside) one of the
+/// paths passed via `--ignore-path`. Ignored directories and all their subfolders
+/// are excluded from feature detection entirely.
+fn is_ignored_path(dir_path: &Path, ignore_paths: &[PathBuf]) -> bool {
+    let Ok(canonical) = fs::canonicalize(dir_path) else {
+        return false;
+    };
+
+    ignore_paths
+        .iter()
+        .any(|ignored| canonical.starts_with(ignored))
 }
 
 fn find_readme_file(dir_path: &Path) -> Option<std::path::PathBuf> {
@@ -101,13 +114,14 @@ fn is_feature_directory(dir_path: &Path) -> bool {
     has_feature_flag_in_readme(dir_path)
 }
 
-pub fn list_files_recursive(dir: &Path) -> Result<Vec<Feature>> {
+pub fn list_files_recursive(dir: &Path, ignore_paths: &[PathBuf]) -> Result<Vec<Feature>> {
     // Scan entire base_path for feature metadata once
     let feature_metadata =
         feature_metadata_detector::scan_directory_for_feature_metadata(dir).unwrap_or_default();
 
     // First pass: build feature structure without dependencies
-    let mut features = list_files_recursive_impl(dir, dir, None, None, &feature_metadata)?;
+    let mut features =
+        list_files_recursive_impl(dir, dir, None, None, &feature_metadata, ignore_paths)?;
 
     // Second pass: scan for imports and resolve dependencies
     populate_dependencies(&mut features, dir)?;
@@ -115,7 +129,10 @@ pub fn list_files_recursive(dir: &Path) -> Result<Vec<Feature>> {
     Ok(features)
 }
 
-pub fn list_files_recursive_with_changes(dir: &Path) -> Result<Vec<Feature>> {
+pub fn list_files_recursive_with_changes(
+    dir: &Path,
+    ignore_paths: &[PathBuf],
+) -> Result<Vec<Feature>> {
     // Get all commits once at the beginning for efficiency
     let all_commits = get_all_commits_by_path(dir).unwrap_or_default();
     // Scan entire base_path for feature metadata once
@@ -123,8 +140,14 @@ pub fn list_files_recursive_with_changes(dir: &Path) -> Result<Vec<Feature>> {
         feature_metadata_detector::scan_directory_for_feature_metadata(dir).unwrap_or_default();
 
     // First pass: build feature structure without dependencies
-    let mut features =
-        list_files_recursive_impl(dir, dir, Some(&all_commits), None, &feature_metadata)?;
+    let mut features = list_files_recursive_impl(
+        dir,
+        dir,
+        Some(&all_commits),
+        None,
+        &feature_metadata,
+        ignore_paths,
+    )?;
 
     // Second pass: scan for imports and resolve dependencies
     populate_dependencies(&mut features, dir)?;
@@ -708,6 +731,7 @@ fn process_feature_directory(
     changes_map: Option<&HashMap<String, Vec<Change>>>,
     parent_owner: Option<&str>,
     feature_metadata_map: &FeatureMetadataMap,
+    ignore_paths: &[PathBuf],
 ) -> Result<Feature> {
     // First try to find and read FEATURES.toml file
     let (title, owner, description, mut meta) = if let Some(toml_path) = find_features_toml(path) {
@@ -807,13 +831,17 @@ fn process_feature_directory(
 
     // Check if this feature has nested features in a 'features' subdirectory
     let nested_features_path = path.join("features");
-    let mut nested_features = if nested_features_path.exists() && nested_features_path.is_dir() {
+    let mut nested_features = if nested_features_path.exists()
+        && nested_features_path.is_dir()
+        && !is_ignored_path(&nested_features_path, ignore_paths)
+    {
         list_files_recursive_impl(
             &nested_features_path,
             base_path,
             changes_map,
             Some(&actual_owner),
             feature_metadata_map,
+            ignore_paths,
         )
         .unwrap_or_default()
     } else {
@@ -834,6 +862,7 @@ fn process_feature_directory(
         if entry_path.is_dir()
             && entry_name != "features" // Don't process 'features' folder twice
             && !is_documentation_directory(&entry_path)
+            && !is_ignored_path(&entry_path, ignore_paths)
         {
             if has_feature_flag_in_readme(&entry_path) {
                 // This directory is a feature itself
@@ -844,6 +873,7 @@ fn process_feature_directory(
                     changes_map,
                     Some(&actual_owner),
                     feature_metadata_map,
+                    ignore_paths,
                 )?;
                 nested_features.push(nested_feature);
             } else {
@@ -855,6 +885,7 @@ fn process_feature_directory(
                     changes_map,
                     Some(&actual_owner),
                     feature_metadata_map,
+                    ignore_paths,
                 )?;
                 nested_features.extend(deeper_features);
             }
@@ -914,6 +945,7 @@ fn list_files_recursive_impl(
     changes_map: Option<&HashMap<String, Vec<Change>>>,
     parent_owner: Option<&str>,
     feature_metadata_map: &FeatureMetadataMap,
+    ignore_paths: &[PathBuf],
 ) -> Result<Vec<Feature>> {
     let entries = fs::read_dir(dir)
         .with_context(|| format!("could not read directory `{}`", dir.display()))?;
@@ -928,6 +960,10 @@ fn list_files_recursive_impl(
         let name = path.file_name().unwrap().to_string_lossy();
 
         if path.is_dir() {
+            if is_ignored_path(&path, ignore_paths) {
+                continue;
+            }
+
             if is_feature_directory(&path) {
                 let feature = process_feature_directory(
                     &path,
@@ -936,6 +972,7 @@ fn list_files_recursive_impl(
                     changes_map,
                     parent_owner,
                     feature_metadata_map,
+                    ignore_paths,
                 )?;
                 features.push(feature);
             } else if !is_documentation_directory(&path)
@@ -948,6 +985,7 @@ fn list_files_recursive_impl(
                     changes_map,
                     parent_owner,
                     feature_metadata_map,
+                    ignore_paths,
                 )?;
                 features.extend(new_features);
             }

--- a/tools/cli/src/http_server.rs
+++ b/tools/cli/src/http_server.rs
@@ -79,6 +79,7 @@ pub async fn serve_features_with_watching(
     watch_path: PathBuf,
     on_ready: Option<Box<dyn FnOnce() + Send>>,
     skip_changes: bool,
+    ignore_paths: Vec<PathBuf>,
 ) -> Result<()> {
     let config = ServerConfig::new(port);
     serve_features_with_config_and_watching(
@@ -87,6 +88,7 @@ pub async fn serve_features_with_watching(
         Some(watch_path.clone()),
         on_ready,
         skip_changes,
+        ignore_paths,
     )
     .await
 }
@@ -110,6 +112,7 @@ pub async fn serve_features_with_config_and_watching(
     watch_path: Option<PathBuf>,
     on_ready: Option<Box<dyn FnOnce() + Send>>,
     skip_changes: bool,
+    ignore_paths: Vec<PathBuf>,
 ) -> Result<()> {
     // Create shared state for features
     let features_data = Arc::new(RwLock::new(features.to_vec()));
@@ -125,7 +128,9 @@ pub async fn serve_features_with_config_and_watching(
         let watch_path_clone = path.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = setup_file_watcher(features_data_clone, watch_path_clone).await {
+            if let Err(e) =
+                setup_file_watcher(features_data_clone, watch_path_clone, ignore_paths).await
+            {
                 eprintln!("File watcher error: {}", e);
             }
         });
@@ -226,6 +231,7 @@ pub async fn serve_features_with_config_and_watching(
 async fn setup_file_watcher(
     features_data: Arc<RwLock<Vec<Feature>>>,
     watch_path: PathBuf,
+    ignore_paths: Vec<PathBuf>,
 ) -> Result<()> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(100);
 
@@ -267,7 +273,7 @@ async fn setup_file_watcher(
             // Add a small delay to avoid excessive recomputation during rapid changes
             sleep(Duration::from_millis(500)).await;
 
-            match list_files_recursive_with_changes(&watch_path) {
+            match list_files_recursive_with_changes(&watch_path, &ignore_paths) {
                 Ok(new_features) => {
                     let mut features = features_data.write().await;
                     *features = new_features;

--- a/tools/cli/src/scan.rs
+++ b/tools/cli/src/scan.rs
@@ -5,7 +5,7 @@
 //! easy-to-use API.
 
 use anyhow::Result;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::coverage_parser::{self, map_coverage_to_features, parse_coverage_reports};
 use crate::file_scanner::{list_files_recursive, list_files_recursive_with_changes};
@@ -29,6 +29,9 @@ pub struct ScanConfig<'a> {
 
     /// Optional project directory (used for finding coverage)
     pub project_dir: Option<&'a Path>,
+
+    /// Paths to ignore (and all their subfolders) when scanning for features
+    pub ignore_paths: Vec<PathBuf>,
 }
 
 impl<'a> ScanConfig<'a> {
@@ -40,6 +43,7 @@ impl<'a> ScanConfig<'a> {
             coverage_dir_override: None,
             current_dir,
             project_dir: None,
+            ignore_paths: Vec::new(),
         }
     }
 
@@ -64,6 +68,12 @@ impl<'a> ScanConfig<'a> {
     /// Set the project directory for finding coverage
     pub fn project_dir(mut self, dir: &'a Path) -> Self {
         self.project_dir = Some(dir);
+        self
+    }
+
+    /// Set the paths to ignore (and all their subfolders) when scanning for features
+    pub fn ignore_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.ignore_paths = paths;
         self
     }
 }
@@ -96,9 +106,9 @@ impl<'a> ScanConfig<'a> {
 pub fn scan_features(base_path: &Path, config: ScanConfig) -> Result<Vec<Feature>> {
     // Step 1: Scan features with or without git history
     let mut features = if config.skip_changes {
-        list_files_recursive(base_path)?
+        list_files_recursive(base_path, &config.ignore_paths)?
     } else {
-        list_files_recursive_with_changes(base_path)?
+        list_files_recursive_with_changes(base_path, &config.ignore_paths)?
     };
 
     // Step 2: Add coverage if requested

--- a/tools/cli/tests/ignore_path_test.rs
+++ b/tools/cli/tests/ignore_path_test.rs
@@ -1,0 +1,65 @@
+//! Integration tests for the `--ignore-path` scanning option.
+//!
+//! Verifies that a path passed via `ScanConfig::ignore_paths` (the CLI's
+//! `--ignore-path` argument) is excluded from the feature tree along with all
+//! of its subfolders, while unrelated features (including ones with the same
+//! name at a different path) are left untouched.
+
+use features_cli::scan::{ScanConfig, scan_features};
+use std::path::PathBuf;
+
+fn feature_paths(features: &[features_cli::models::Feature], out: &mut Vec<String>) {
+    for feature in features {
+        out.push(feature.path.clone());
+        feature_paths(&feature.features, out);
+    }
+}
+
+#[test]
+fn test_ignore_path_excludes_folder_and_subfolders() {
+    let test_path = PathBuf::from("../../examples/tests-skip-changes/src");
+
+    if !test_path.exists() {
+        println!("Skipping test - test path does not exist");
+        return;
+    }
+
+    // Sanity check: without ignoring anything, feature-1 (with its nested
+    // feature-2/3/4) and the same-named libs/features/feature-1 both show up.
+    let config = ScanConfig::new(&test_path).skip_changes(true);
+    let features = scan_features(&test_path, config).expect("scan should succeed");
+
+    let mut all_paths = Vec::new();
+    feature_paths(&features, &mut all_paths);
+
+    assert!(all_paths.contains(&"features/feature-1".to_string()));
+    assert!(all_paths.contains(&"features/feature-1/features/feature-2".to_string()));
+    assert!(all_paths.contains(&"features/feature-1/features/feature-3".to_string()));
+    assert!(all_paths.contains(&"features/feature-1/features/feature-4".to_string()));
+    assert!(all_paths.contains(&"libs/features/feature-1".to_string()));
+
+    // Now ignore `features/feature-1`.
+    let ignored_path = test_path.join("features/feature-1");
+    let canonical_ignored_path =
+        std::fs::canonicalize(&ignored_path).expect("ignored path should exist");
+
+    let config = ScanConfig::new(&test_path)
+        .skip_changes(true)
+        .ignore_paths(vec![canonical_ignored_path]);
+    let features = scan_features(&test_path, config).expect("scan should succeed");
+
+    let mut ignored_paths = Vec::new();
+    feature_paths(&features, &mut ignored_paths);
+
+    // The ignored feature and all of its nested subfolders are gone.
+    assert!(!ignored_paths.contains(&"features/feature-1".to_string()));
+    assert!(!ignored_paths.contains(&"features/feature-1/features/feature-2".to_string()));
+    assert!(!ignored_paths.contains(&"features/feature-1/features/feature-3".to_string()));
+    assert!(!ignored_paths.contains(&"features/feature-1/features/feature-4".to_string()));
+
+    // A same-named feature at a different path is unaffected.
+    assert!(ignored_paths.contains(&"libs/features/feature-1".to_string()));
+    // Unrelated features are unaffected.
+    assert!(ignored_paths.contains(&"features/feature-0".to_string()));
+    assert!(ignored_paths.contains(&"features/feature-2".to_string()));
+}


### PR DESCRIPTION
## Summary

Adds a new `--ignore-path <path>` CLI argument (repeatable) that excludes a folder — and everything nested inside it — from feature detection.

Previously there was no way to opt a folder under a `features/` directory out of being treated as a feature; the only knobs were the `feature: true` frontmatter flag (opt-in only) and hard-coded doc-folder names (`docs`, `__docs__`, `.docs`).

## Changes

- `tools/cli/src/file_scanner.rs`: new `is_ignored_path` helper; `ignore_paths` threaded through `list_files_recursive`, `list_files_recursive_with_changes`, `list_files_recursive_impl`, and `process_feature_directory`. Ignored directories are skipped before feature detection and before recursing into subfolders, so nested content is excluded too.
- `tools/cli/src/scan.rs`: `ScanConfig` gains an `ignore_paths: Vec<PathBuf>` field and `.ignore_paths()` builder method.
- `tools/cli/src/bin.rs`: new `--ignore-path` arg (`Vec<PathBuf>`, can be repeated). Relative paths are resolved against the current directory and canonicalized; paths that don't exist print a warning and are skipped rather than failing the scan.
- `tools/cli/src/http_server.rs`: `ignore_paths` threaded through `serve_features_with_watching` / `serve_features_with_config_and_watching` / `setup_file_watcher` so live-reload rescans on file changes also honor the ignore list.
- `README.md`: documented the new flag in the CLI options table.
- `tools/cli/tests/ignore_path_test.rs`: new integration test verifying an ignored feature and its nested subfolders are excluded, while a same-named feature at a different path (and unrelated features) remain untouched.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (all existing + new tests pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] Manually verified via `cargo run -- <dir> --ignore-path <folder>` that the folder and its nested features disappear from the output while a same-named feature elsewhere is unaffected, and that a nonexistent `--ignore-path` prints a warning instead of erroring.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UZqLmxnpfmpAMV5fxgD4ui)_