### PR TITLE
feat: skip a feature via `feature: false` README property

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ owner: backend-team
 
 This allows features to be organized anywhere in your codebase while still being discoverable by the tools.
 
+Conversely, adding `feature: false` skips a folder from being detected as a feature, even if it's a direct subfolder of a `features` folder. Unlike `--ignore-path`, its subfolders are still scanned, so any nested features it contains are still discovered:
+
+```yaml
+---
+feature: false
+---
+```
+
 ### Feature Metadata Annotations
 
 You can annotate your code with feature metadata using special comments. These annotations can be placed **anywhere in your codebase** and will be automatically associated with the matching feature:

--- a/docs/readme-format.md
+++ b/docs/readme-format.md
@@ -16,3 +16,13 @@ deprecated: true # true, false
 # Feature Name (Override the feature folder name if provided)
 
 ```
+
+### Skipping a feature
+
+Setting `feature: false` explicitly skips a folder from being detected as a feature, even if it's a direct subfolder of a `features` folder. Unlike `--ignore-path`, its subfolders are still scanned, so any nested features it contains (via its own `features` folder or their own `feature: true` README) are still discovered:
+
+```markdown
+---
+feature: false
+---
+```

--- a/projects/cli/src/file_scanner.rs
+++ b/projects/cli/src/file_scanner.rs
@@ -71,37 +71,48 @@ fn find_readme_file(dir_path: &Path) -> Option<std::path::PathBuf> {
     None
 }
 
+/// Read the `feature` boolean from a directory's README front matter, if present.
+fn feature_flag_in_readme(dir_path: &Path) -> Option<bool> {
+    let readme_path = find_readme_file(dir_path)?;
+    let content = fs::read_to_string(&readme_path).ok()?;
+
+    // Check if content starts with YAML front matter (---)
+    let stripped = content.strip_prefix("---\n")?;
+    let end_pos = stripped.find("\n---\n")?;
+    let yaml_content = &stripped[..end_pos];
+
+    // Parse YAML front matter
+    let yaml_value = serde_yaml::from_str::<serde_yaml::Value>(yaml_content).ok()?;
+    let mapping = yaml_value.as_mapping()?;
+    let feature_value = mapping.get(serde_yaml::Value::String("feature".to_string()))?;
+
+    feature_value.as_bool()
+}
+
 /// Check if a directory has a README with `feature: true` in front matter
 fn has_feature_flag_in_readme(dir_path: &Path) -> bool {
-    if let Some(readme_path) = find_readme_file(dir_path)
-        && let Ok(content) = fs::read_to_string(&readme_path)
-    {
-        // Check if content starts with YAML front matter (---)
-        if let Some(stripped) = content.strip_prefix("---\n")
-            && let Some(end_pos) = stripped.find("\n---\n")
-        {
-            let yaml_content = &stripped[..end_pos];
+    feature_flag_in_readme(dir_path) == Some(true)
+}
 
-            // Parse YAML front matter
-            if let Ok(yaml_value) = serde_yaml::from_str::<serde_yaml::Value>(yaml_content)
-                && let Some(mapping) = yaml_value.as_mapping()
-            {
-                // Check for feature: true
-                if let Some(feature_value) =
-                    mapping.get(serde_yaml::Value::String("feature".to_string()))
-                {
-                    return feature_value.as_bool() == Some(true);
-                }
-            }
-        }
-    }
-    false
+/// Check if a directory has a README with `feature: false` in front matter.
+/// This is used to explicitly skip a directory from being treated as a feature,
+/// even when it would otherwise qualify (e.g. a direct subfolder of `features`).
+fn has_feature_false_in_readme(dir_path: &Path) -> bool {
+    feature_flag_in_readme(dir_path) == Some(false)
 }
 
 /// Check if a directory should be treated as a feature
 fn is_feature_directory(dir_path: &Path) -> bool {
     // Skip documentation directories
     if is_documentation_directory(dir_path) || is_inside_documentation_directory(dir_path) {
+        return false;
+    }
+
+    // An explicit `feature: false` in the README always skips this directory
+    // from being a feature itself, even if it would otherwise qualify (e.g. a
+    // direct subfolder of `features`). Its own subfolders are still scanned
+    // normally, so any nested features it contains are kept.
+    if has_feature_false_in_readme(dir_path) {
         return false;
     }
 
@@ -1081,5 +1092,139 @@ mod tests {
             extract_commit_type("feat(scope)(weird): nested parens"),
             "feat"
         );
+    }
+
+    fn write_readme(dir: &Path, content: &str) {
+        fs::write(dir.join("README.md"), content).unwrap();
+    }
+
+    #[test]
+    fn test_feature_flag_in_readme_true() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        write_readme(temp_dir.path(), "---\nfeature: true\n---\n\n# Feature\n");
+
+        assert_eq!(feature_flag_in_readme(temp_dir.path()), Some(true));
+        assert!(has_feature_flag_in_readme(temp_dir.path()));
+        assert!(!has_feature_false_in_readme(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_feature_flag_in_readme_false() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        write_readme(temp_dir.path(), "---\nfeature: false\n---\n\n# Feature\n");
+
+        assert_eq!(feature_flag_in_readme(temp_dir.path()), Some(false));
+        assert!(!has_feature_flag_in_readme(temp_dir.path()));
+        assert!(has_feature_false_in_readme(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_feature_flag_in_readme_missing() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        // No README at all
+        assert_eq!(feature_flag_in_readme(temp_dir.path()), None);
+        assert!(!has_feature_flag_in_readme(temp_dir.path()));
+        assert!(!has_feature_false_in_readme(temp_dir.path()));
+
+        // README without a `feature` property
+        write_readme(temp_dir.path(), "---\nowner: team\n---\n\n# Feature\n");
+        assert_eq!(feature_flag_in_readme(temp_dir.path()), None);
+        assert!(!has_feature_flag_in_readme(temp_dir.path()));
+        assert!(!has_feature_false_in_readme(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_is_feature_directory_direct_subfolder_of_features() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let features_dir = temp_dir.path().join("features");
+        let feature_dir = features_dir.join("my-feature");
+        fs::create_dir_all(&feature_dir).unwrap();
+
+        // No README needed: a direct subfolder of `features` is a feature by default
+        assert!(is_feature_directory(&feature_dir));
+    }
+
+    #[test]
+    fn test_is_feature_directory_skips_when_feature_false_even_under_features_folder() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let features_dir = temp_dir.path().join("features");
+        let feature_dir = features_dir.join("my-feature");
+        fs::create_dir_all(&feature_dir).unwrap();
+        write_readme(&feature_dir, "---\nfeature: false\n---\n\n# My Feature\n");
+
+        // Explicit `feature: false` overrides the "direct subfolder of `features`" rule
+        assert!(!is_feature_directory(&feature_dir));
+    }
+
+    #[test]
+    fn test_is_feature_directory_readme_feature_true_outside_features_folder() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let feature_dir = temp_dir.path().join("some-dir");
+        fs::create_dir_all(&feature_dir).unwrap();
+        write_readme(&feature_dir, "---\nfeature: true\n---\n\n# Some Dir\n");
+
+        assert!(is_feature_directory(&feature_dir));
+    }
+
+    #[test]
+    fn test_is_feature_directory_readme_feature_false_outside_features_folder() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let feature_dir = temp_dir.path().join("some-dir");
+        fs::create_dir_all(&feature_dir).unwrap();
+        write_readme(&feature_dir, "---\nfeature: false\n---\n\n# Some Dir\n");
+
+        assert!(!is_feature_directory(&feature_dir));
+    }
+
+    /// Skipping a feature via `feature: false` must keep its sub-children discoverable:
+    /// both a nested `features/` folder and a subfolder with its own `feature: true` README.
+    #[test]
+    fn test_list_files_recursive_skips_feature_but_keeps_sub_children() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let base = temp_dir.path();
+
+        let features_dir = base.join("features");
+        let skipped_dir = features_dir.join("skipped-feature");
+        fs::create_dir_all(&skipped_dir).unwrap();
+        write_readme(
+            &skipped_dir,
+            "---\nfeature: false\nowner: skipped-owner\n---\n\n# Skipped Feature\n",
+        );
+
+        // A nested `features` folder inside the skipped directory.
+        let nested_via_features_folder = skipped_dir.join("features").join("child-a");
+        fs::create_dir_all(&nested_via_features_folder).unwrap();
+
+        // A subfolder marked as a feature via its own README.
+        let nested_via_readme = skipped_dir.join("child-b");
+        fs::create_dir_all(&nested_via_readme).unwrap();
+        write_readme(
+            &nested_via_readme,
+            "---\nfeature: true\nowner: child-b-owner\n---\n\n# Child B\n",
+        );
+
+        let features = list_files_recursive(base, &[]).unwrap();
+
+        // The skipped feature itself must not appear anywhere in the tree.
+        fn collect_names(features: &[Feature], out: &mut Vec<String>) {
+            for feature in features {
+                out.push(feature.name.clone());
+                collect_names(&feature.features, out);
+            }
+        }
+        let mut names = Vec::new();
+        collect_names(&features, &mut names);
+        assert!(!names.contains(&"skipped-feature".to_string()));
+        assert!(!names.contains(&"Skipped Feature".to_string()));
+
+        // Both sub-children are still discovered, as top-level features (since their
+        // skipped parent no longer exists as a node in the tree).
+        assert!(names.contains(&"child-a".to_string()));
+        let child_b = features
+            .iter()
+            .find(|f| f.name == "Child B")
+            .expect("child-b feature should be present");
+        assert_eq!(child_b.owner, "child-b-owner");
     }
 }

--- a/projects/cli/tests/skip_feature_readme_test.rs
+++ b/projects/cli/tests/skip_feature_readme_test.rs
@@ -1,0 +1,100 @@
+//! Integration tests for skipping a feature via the README `feature: false` property.
+//!
+//! Unlike `--ignore-path`, which excludes a folder *and all of its subfolders*
+//! from scanning, marking a feature's README with `feature: false` only skips
+//! that feature itself: any nested features it contains (via a `features/`
+//! subfolder or their own `feature: true` README) are still discovered.
+
+use features_cli::models::Feature;
+use features_cli::scan::{ScanConfig, scan_features};
+use std::fs;
+use tempfile::TempDir;
+
+fn write_readme(dir: &std::path::Path, content: &str) {
+    fs::write(dir.join("README.md"), content).unwrap();
+}
+
+fn feature_names(features: &[Feature], out: &mut Vec<String>) {
+    for feature in features {
+        out.push(feature.name.clone());
+        feature_names(&feature.features, out);
+    }
+}
+
+#[test]
+fn test_feature_false_skips_direct_subfolder_of_features_but_keeps_nested_features_folder() {
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path();
+
+    let skipped_dir = base.join("features").join("skipped-feature");
+    fs::create_dir_all(&skipped_dir).unwrap();
+    write_readme(&skipped_dir, "---\nfeature: false\n---\n\n# Skipped\n");
+
+    // Nested feature living inside the skipped feature's own `features/` folder.
+    let nested_dir = skipped_dir.join("features").join("nested-feature");
+    fs::create_dir_all(&nested_dir).unwrap();
+
+    let config = ScanConfig::new(base).skip_changes(true);
+    let features = scan_features(base, config).expect("scan should succeed");
+
+    let mut names = Vec::new();
+    feature_names(&features, &mut names);
+
+    assert!(!names.contains(&"skipped-feature".to_string()));
+    assert!(names.contains(&"nested-feature".to_string()));
+}
+
+#[test]
+fn test_feature_false_skips_feature_but_keeps_readme_marked_sub_children() {
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path();
+
+    let skipped_dir = base.join("features").join("skipped-feature");
+    fs::create_dir_all(&skipped_dir).unwrap();
+    write_readme(
+        &skipped_dir,
+        "---\nfeature: false\nowner: skipped-owner\n---\n\n# Skipped\n",
+    );
+
+    // A subfolder that isn't inside a `features/` folder, but declares itself
+    // a feature via its own README.
+    let child_dir = skipped_dir.join("child");
+    fs::create_dir_all(&child_dir).unwrap();
+    write_readme(
+        &child_dir,
+        "---\nfeature: true\nowner: child-owner\n---\n\n# Child\n",
+    );
+
+    let config = ScanConfig::new(base).skip_changes(true);
+    let features = scan_features(base, config).expect("scan should succeed");
+
+    let mut names = Vec::new();
+    feature_names(&features, &mut names);
+
+    assert!(!names.contains(&"Skipped".to_string()));
+    let child = features
+        .iter()
+        .find(|f| f.name == "Child")
+        .expect("child feature should still be discovered");
+    assert_eq!(child.owner, "child-owner");
+}
+
+#[test]
+fn test_feature_true_direct_subfolder_still_included_by_default() {
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path();
+
+    let feature_dir = base.join("features").join("regular-feature");
+    fs::create_dir_all(&feature_dir).unwrap();
+
+    let config = ScanConfig::new(base).skip_changes(true);
+    let features = scan_features(base, config).expect("scan should succeed");
+
+    let mut names = Vec::new();
+    feature_names(&features, &mut names);
+
+    // Sanity check: a direct subfolder of `features` with no README is still
+    // treated as a feature (existing behavior), confirming that the skip in
+    // the tests above is due to `feature: false` and not some other cause.
+    assert!(names.contains(&"regular-feature".to_string()));
+}


### PR DESCRIPTION
## Summary

- In addition to `--ignore-path`, a directory can now opt out of being treated as a feature by setting `feature: false` in its README frontmatter — even when it's a direct subfolder of a `features` folder (where a folder is normally treated as a feature by default).
- Unlike `--ignore-path`, which excludes a folder **and all of its subfolders**, `feature: false` only skips that specific feature. Any nested features it contains (via its own `features/` subfolder, or subfolders with their own `feature: true` README) are still discovered and promoted to the surrounding tree.
- Refactored `has_feature_flag_in_readme` and the new `has_feature_false_in_readme` to share a single `feature_flag_in_readme` YAML-parsing helper instead of duplicating the frontmatter-parsing logic.

## Test plan

- [x] `cargo test` (all 61 tests pass, including new unit tests in `file_scanner.rs` and a new integration test file `tests/skip_feature_readme_test.rs`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check`
- New unit tests cover: `feature_flag_in_readme` parsing (true/false/missing), `is_feature_directory` overriding the "direct subfolder of `features`" rule when `feature: false` is set, and README-declared `feature: true`/`false` outside a `features` folder.
- New integration tests (using `ScanConfig`/`scan_features`) cover: skipping a direct subfolder of `features` while keeping its nested `features/` folder, skipping a feature while keeping a README-marked child, and a sanity check that default detection is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hoeYpt5QavNVKJ1E36LaM)_