### PR TITLE
Bump features-cli version to 0.12.0

### DIFF
--- a/projects/cli/Cargo.lock
+++ b/projects/cli/Cargo.lock
@@ -354,7 +354,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "features-cli"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/projects/cli/Cargo.toml
+++ b/projects/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "features-cli"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 description = "A CLI tool for discovering the features in a folder"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump `features-cli` version from `0.11.7` to `0.12.0` in `projects/cli/Cargo.toml`
- Update matching version entry in `projects/cli/Cargo.lock`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRDBKVHj3dhyq1ne5iDNox)_